### PR TITLE
Fix URL where to fetch 99-platformio-udev.rules

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fLo /etc/udev/rules.d/99-platformio-udev.rules --create-dirs https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules
+RUN curl -fLo /etc/udev/rules.d/99-platformio-udev.rules --create-dirs https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules
 
 USER $USERNAME
 


### PR DESCRIPTION
The URL where 99-platformio-udev.rules can be retrieved has changed.

Please refer to the updated documentation on
https://docs.platformio.org/en/stable/core/installation/udev-rules.html