### PR TITLE
updated `get-platformio.py` installer URL

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,4 +26,5 @@ RUN curl -fLo /etc/udev/rules.d/99-platformio-udev.rules --create-dirs https://r
 
 USER $USERNAME
 
-RUN python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/develop/scripts/get-platformio.py)"
+# updated to new URL according https://docs.platformio.org/en/latest/core/installation/methods/installer-script.html#super-quick-macos-linux
+RUN python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py)"


### PR DESCRIPTION
This looks good, I'll test it later today and merge it if everything works.

Maybe I should set up some kind of alert to notify me when this URL is no longer valid since it happens more often than I would expect

Thanks @bugrasan