### PR TITLE
README update of container host OS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 | *Contributors*              | [On Github](https://github.com/prenone/platformio-vscode-devcontainer/graphs/contributors)    |
 | *Categories*                | IoT                            |
 | *Definition type*           | Dockerfile                     |
-| *Container host OS support* | Linux, macOS (not tested),     |
+| *Container host OS support* | Linux                          |
 | *Container OS*              | Debian (`bookworm`, `bullseye`)|
 | *Languages, platforms*      | PlatformIO, C++, Python        |
+
+MacOS version of Docker does not support USB Passthrough, so downloading and serial port monitoring is not possible from a Docker container at this time. [USB Passthrough on macOS](https://github.com/docker/roadmap/issues/511)
 
 ## Using this definition
 


### PR DESCRIPTION
I have carried out some tests on Apple using a vscode devcontainer with Platformio and your template but it is not really conclusive.

HyperKit appears to support USB passthrough to date but the functionality is not yet integrated by the Docker development team.

Related issues:
- https://github.com/docker/roadmap/issues/744
- https://github.com/docker/roadmap/issues/511
- https://github.com/moby/hyperkit/issues/149
- https://github.com/moby/hyperkit/issues/40
- https://github.com/docker/for-mac/issues/5263