### PR TITLE
atomic apt update & install

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,12 +1,12 @@
 ARG VARIANT=bookworm
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 
-RUN sudo apt-get update
-RUN export DEBIAN_FRONTEND=noninteractive && \
-  sudo apt-get -y install --no-install-recommends \
-  clang \
-  python3-venv \
-  udev
+ENV DEBIAN_FRONTEND=noninteractive
+RUN sudo apt-get update \
+ && sudo apt-get -y install --no-install-recommends \
+      clang \
+      python3-venv \
+      udev
 
 ## Set up udev rules for PlatformIO
 RUN curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules


### PR DESCRIPTION
Fixed calls to `apt` when building the container.

## Why?
Docker creates layers per `RUN` in the `Dockerfile` (in this case `Containerfile`).
When building with cache, docker will re-use layers that remain the same, and progress from where they _have_ changed.

In the case of `apt update`, and `apt install` in separate layers, you can end up with an `apt update` being old (using an old list of application versions and dependencies), and the `apt install` referencing new, or changed modules.
This can result in a re-build referencing a now defunct database of packages, being downloaded from a package repository that is no longer represented by the old database.

Easy fix... make them part of the same step; the same "layer"

It's a small thing, but could cause headaches that go unreported.
I just noticed it while browsing, & thought I'd contribute.